### PR TITLE
chore: add page for google search console verification

### DIFF
--- a/static/googlec27d802776ac705b.html
+++ b/static/googlec27d802776ac705b.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec27d802776ac705b.html


### PR DESCRIPTION
This adds an html page to verify "ownership" of the website so that we can use Google Search Console. I have read that this should give us tools to help understand why the site isn't being indexed now and what we can do to fix it. 