### PR TITLE
chore: optimize description keywords for indexing

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,13 +1,13 @@
 ---
 title: "Blue Mountains Soaring Club"
 linkTitle: "BMSC Home"
-description: "Free Flying in the Blue Mountains and Central Tablelands"
+description: "Paragliding and hang gliding club in the Blue Mountains with a main launch site at Mount Blackheath"
 date: 2022-05-13T16:25:13+10:00
 draft: false
 cascade:
   featured_image: "/img/blackheath-launch-evening.jpg"
 ---
 
-Welcome to the Blue Mountains Soaring Club. We're committed to providing **safe and regular free-flying opportunities throughout the Blue Mountains and Central Tablelands** to the west of Sydney for all of our members and visiting pilots.
+Welcome to the Blue Mountains Soaring Club. We're committed to providing **safe and regular paragliding and hang gliding opportunities throughout the Blue Mountains and Central Tablelands** to the west of Sydney for all of our members and visiting pilots.
 
 Please read our [important information before you fly]({{< ref "/before-you-fly" >}}), or join us and [become a member]({{< ref "/become-a-member" >}}). If you have other questions that aren't yet answered here, please [contact us]({{< ref "/contact" >}}).


### PR DESCRIPTION
#9 
Google has indexed all the pages in the site, but searches such as "Blue Mountains Paragliding", that I think would be most likely to be used, still fail to return the site on the first page of results. I think we might be able to improve this by including the terms "Paragliding", "Hang gliding" and "Mount Blackheath" in the  meta description (At the moment, a search of "blue mountains free flying" returns the club website as the second result).